### PR TITLE
test: use client.deployDataUnion for DU deployments

### DIFF
--- a/packages/client/test/unit/deploy.test.ts
+++ b/packages/client/test/unit/deploy.test.ts
@@ -41,14 +41,14 @@ describe('DataUnion deploy', () => {
             const client = new DataUnionClient(clientOptions)
             const dataUnion = await client.deployDataUnion()
             expect(await dataUnion.getAdminAddress()).toBe(await client.getAddress())
-        }, 30000)
+        })
 
         it('specified', async () => {
             const owner = "0x0000000000000000000000000000000000000123"
             const client = new DataUnionClient(clientOptions)
             const dataUnion = await client.deployDataUnion({ owner })
             expect(await dataUnion.getAdminAddress()).toBe(owner)
-        }, 30000)
+        })
 
         it('invalid', async () => {
             const client = new DataUnionClient(clientOptions)

--- a/packages/client/test/unit/fees.test.ts
+++ b/packages/client/test/unit/fees.test.ts
@@ -68,7 +68,7 @@ describe('DataUnion fees', () => {
         const newFee = await dataUnion.getAdminFee()
         expect(oldFee).toEqual(0)
         expect(newFee).toEqual(0.1)
-    }, 30000)
+    })
 
     it('admin receives admin fees', async () => {
         const client = new DataUnionClient(clientOptions)
@@ -77,7 +77,7 @@ describe('DataUnion fees', () => {
         await dataUnion.setAdminFee(0.1)
         await fundDataUnion(dataUnion.getAddress(), parseEther('1'))
         expect(formatEther(await dataUnion.getWithdrawableEarnings(user.address))).toEqual('0.1')
-    }, 30000)
+    })
 
     // it('admin can set DU fee', async () => {
     //     const client = new DataUnionClient(clientOptions)
@@ -90,7 +90,7 @@ describe('DataUnion fees', () => {
     //     const newFee = await dataUnion.getAdminFee()
     //     expect(oldFee).toEqual(0)
     //     expect(newFee).toEqual(0.1)
-    // }, 30000)
+    // })
 
     it('DU DAO receives DU fees', async () => {
         const client = new DataUnionClient(clientOptions)
@@ -99,5 +99,5 @@ describe('DataUnion fees', () => {
         await dataUnion.setDataUnionFee(0.1)
         await fundDataUnion(dataUnion.getAddress(), parseEther('1'))
         expect(formatEther(await dataUnion.getWithdrawableEarnings(duDAO.address))).toEqual('0.1')
-    }, 30000)
+    })
 })

--- a/packages/client/test/unit/setup.ts
+++ b/packages/client/test/unit/setup.ts
@@ -1,10 +1,9 @@
-import { Contract, ContractFactory } from '@ethersproject/contracts'
+import { ContractFactory } from '@ethersproject/contracts'
 import { Web3Provider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
 import * as ganache from 'ganache'
 
 import { deployToken } from '@streamr/data-v2'
-import type { DATAv2 } from '@streamr/data-v2'
 
 import { dataUnionTemplate as templateJson, dataUnionFactory as factoryJson } from '@dataunions/contracts'
 import type { DataUnionTemplate, DataUnionFactory } from '@dataunions/contracts/typechain'
@@ -83,31 +82,4 @@ export async function deployContracts(deployer: Wallet) {
         dataUnionTemplate,
         ethereumUrl: `http://localhost:${ethereumRpcPort}`,
     }
-}
-
-// TODO: remove this, use client.deployDataUnion() instead
-export async function deployDataUnion(duFactory: DataUnionFactory, token: DATAv2): Promise<DataUnionTemplate> {
-    const ownerAddress = await duFactory.signer.getAddress()
-    // function deployNewDataUnionUsingToken(
-    //     address token,
-    //     address payable owner,
-    //     address[] memory agents,
-    //     uint256 initialAdminFeeFraction,
-    //     uint256 initialDataUnionFeeFraction,
-    //     address initialDataUnionBeneficiary
-    // )
-    const tx = await duFactory.deployNewDataUnionUsingToken(
-        token.address,
-        ownerAddress,
-        [ownerAddress],
-        "0",
-        "0",
-        "0x0000000000000000000000000000000000000000"
-    )
-    const receipt = await tx.wait()
-    const createdEvent = receipt.events?.find((e) => e.event === 'DUCreated')
-    if (createdEvent == null) { throw new Error('Factory did not emit a DUCreated event!') }
-    const contractAddress = createdEvent.args!.du
-    log(`DataUnion deployed at ${contractAddress}`)
-    return new Contract(contractAddress, templateJson.abi, duFactory.signer) as unknown as DataUnionTemplate
 }


### PR DESCRIPTION
instead of the "explicit" contract deployment that I used BEFORE client.deployDataUnion existed